### PR TITLE
build: Upgrade to go 1.17

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -2,7 +2,7 @@ name: 'Unit Tests'
 description: 'Run unit tests using go'
 inputs:
   GO_VERSION:
-    default: "1.16"
+    default: "1.17"
 env:
   GO111MODULE: "on"
   GOPROXY: "https://proxy.golang.org"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
       - name: Check out code.
         uses: actions/checkout@v2.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.16.2-alpine as builder
+FROM golang:1.17.5-alpine as builder
 RUN apk add --no-cache gcc libc-dev git
 
 ARG version=develop

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,31 @@
 module github.com/keptn-contrib/argo-service
 
-go 1.16
+go 1.17
 
 require (
-	github.com/cloudevents/sdk-go/observability/opentelemetry/v2 v2.8.0 // indirect
 	github.com/cloudevents/sdk-go/v2 v2.8.0
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/keptn/go-utils v0.13.0
+)
+
+require (
+	github.com/benbjohnson/clock v1.3.0 // indirect
+	github.com/cloudevents/sdk-go/observability/opentelemetry/v2 v2.8.0 // indirect
+	github.com/felixge/httpsnoop v1.0.2 // indirect
+	github.com/go-logr/logr v1.2.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.29.0 // indirect
 	go.opentelemetry.io/otel v1.4.1 // indirect
+	go.opentelemetry.io/otel/internal/metric v0.27.0 // indirect
+	go.opentelemetry.io/otel/metric v0.27.0 // indirect
+	go.opentelemetry.io/otel/trace v1.4.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
Upgrade to Go 1.17

*Note* from https://go.dev/doc/go1.17:
> If a module specifies go 1.17 or higher, the module graph includes only the immediate dependencies of other go 1.17 modules, not their full transitive dependencies. (See [Module graph pruning](https://go.dev/ref/mod#graph-pruning) for more detail.)
>  For the go command to correctly resolve transitive imports using the pruned module graph, the go.mod file for each module needs to include more detail about the transitive dependencies relevant to that module. If a module specifies go 1.17 or higher in its go.mod file, its go.mod file now contains an explicit require directive for every module that provides a transitively-imported package. (In previous versions, the go.mod file typically only included explicit requirements for directly-imported packages.) 

