### PR TITLE
build: Update service to Keptn 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Future versions of this service may support additional integrations with other c
 |     0.8.4     |                            keptncontrib/argo-service:0.8.4                            |
 | 0.9.0 - 0.9.2 |                            keptncontrib/argo-service:0.9.0                            |
 |    0.10.x     |                            keptncontrib/argo-service:0.9.1                            |
+|    0.12.x     |                            keptncontrib/argo-service:0.9.2                            |
 
 ## Argo Rollout Support Explained
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -84,6 +84,8 @@ spec:
               value: "{{ .Values.distributor.projectFilter }}"
             - name: SERVICE_FILTER
               value: "{{ .Values.distributor.serviceFilter }}"
+            - name: DISTRIBUTOR_VERSION
+              value: {{ .Values.distributor.image.tag | default .Chart.AppVersion }}
             - name: VERSION
               valueFrom:
                 fieldRef:
@@ -116,6 +118,11 @@ spec:
             - name: HTTP_SSL_VERIFY
               {{- $apiValidateTls := .Values.remoteControlPlane.api.apiValidateTls | ternary "true" "false" }}
               value: "{{ $apiValidateTls }}"
+            {{- end }}
+            - name: PUBSUB_GROUP
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/name']
             {{- end }}
 
       {{- with .Values.nodeSelector }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -52,13 +52,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 10999
+              port: 8080
             initialDelaySeconds: 0
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
-              port: 10999
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
           imagePullPolicy: {{ .Values.distributor.image.pullPolicy }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,7 +17,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.10.0"                            # Container Tag
+    tag: "0.12.3"                            # Container Tag
 
 remoteControlPlane:
   enabled: false                             # Enables remote execution plane mode

--- a/releasenotes/releasenotes_V0.9.2.md
+++ b/releasenotes/releasenotes_V0.9.2.md
@@ -1,0 +1,5 @@
+# Release Notes 0.9.2
+
+## New Features
+
+- Update `keptn/distributor` to version `0.12.3`

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -23,7 +23,7 @@ deploy:
         overrides:
           distributor:
             image:
-              tag: 0.10.0
+              tag: 0.12.3
           resources:
             limits:
               memory: 512Mi


### PR DESCRIPTION
Update the Argo-Service to be compatible with Keptn version `0.12.x`.

## Fixes
#51 