### PR TITLE
ci: Restrict rennovate to non office hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base",
     ":gitSignOff",
+    "schedule:nonOfficeHours",
     ":semanticCommits",
     ":semanticCommitTypeAll(build)",
     ":semanticCommitScope(deps)",

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "extends": [
     "config:base",
     ":gitSignOff",
-    "schedule:nonOfficeHours",
     ":semanticCommits",
     ":semanticCommitTypeAll(build)",
     ":semanticCommitScope(deps)",
@@ -11,5 +10,9 @@
   "addLabels": ["dependencies"],
   "cloneSubmodules": true,
   "stabilityDays": 7,
-  "timezone": "Europe/Vienna"
+  "timezone": "Europe/Vienna",
+  "schedule": [
+    "after 10pm on Wednesday",
+    "before 8am on Thursday"
+  ]
 }


### PR DESCRIPTION
## This PR
* Limits rennovate activity to outside office hours (10pm Wed - 8am Thu), similar to the configuration in the keptn/keptn repository