### PR TITLE
feat: Upgrade to Keptn 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Future versions of this service may support additional integrations with other c
 | 0.9.0 - 0.9.2 |                            keptncontrib/argo-service:0.9.0                            |
 |    0.10.x     |                            keptncontrib/argo-service:0.9.1                            |
 |    0.12.x     |                            keptncontrib/argo-service:0.9.2                            |
+|    0.13.x     |                            keptncontrib/argo-service:0.9.3                            |
 
 **Note**: This integration is currently incompatible with Keptn 0.14.x and newer.
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,7 +17,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.12.3"                            # Container Tag
+    tag: "0.13.4"                            # Container Tag
 
 remoteControlPlane:
   enabled: false                             # Enables remote execution plane mode

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -23,7 +23,7 @@ deploy:
         overrides:
           distributor:
             image:
-              tag: 0.12.3
+              tag: 0.13.4
           resources:
             limits:
               memory: 512Mi


### PR DESCRIPTION
## This PR

- Upgrades distributor to Keptn 0.13.4
- Upgrades go-utils to v0.13
- Updates compatibility matrix 